### PR TITLE
Make the weekly.yml link in lts-backports-changelog optional + Support HTTPS URLs as a source of weekly.yml in lts-backports-changelog+ Fix failures of lts-backports-changelog on platforms where bash is not a default shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby
 
+RUN apt-get update && apt-get upgrade -y && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
 COPY generate-jenkins-changelog.rb /jenkins-changelog-generator/bin/generate-jenkins-changelog
 COPY lts-backports-changelog.rb /jenkins-changelog-generator/bin/lts-backports-changelog
 COPY docker-runner.rb /jenkins-changelog-generator/bin/jenkins-changelog-generator

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ docker run -e GITHUB_AUTH=${GITHUB_AUTH} -v $(pwd):/github/workspace --rm onenas
 # lts-backports-changelog
 
 This tool can be used to generate an LTS changelog for all the backported issues (labeled `2.xyz.w-fixed` in Jira) with corresponding changelog entries in the weekly changelog YAML file.
+Weekly changelog YAML is optional, it will be downloaded from the [jenkins.io repository](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml) if not specified.
 
 ## Usage in CLI
 
@@ -58,5 +59,5 @@ export JIRA_AUTH=jira_username:jira_password
 Example:
 
 ```sh
-docker run -e GITHUB_AUTH=${GITHUB_AUTH} -e CHANGELOG_TYPE=lts -v $(pwd):/github/workspace --rm onenashev/jenkins-changelog-generator 2.109.2
+docker run -e GITHUB_AUTH=${GITHUB_AUTH} -e JIRA_AUTH=${JIRA_AUTH} -e CHANGELOG_TYPE=lts -v $(pwd):/github/workspace --rm onenashev/jenkins-changelog-generator 2.190.3
 ```

--- a/lts-backports-changelog.rb
+++ b/lts-backports-changelog.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 require 'yaml'
+require "open-uri"
+require 'shellwords'
 
 git_repo = Dir.pwd
 
@@ -8,12 +10,15 @@ issues = []
 
 curl_auth = ENV['JIRA_AUTH']
 
-if ARGV.length != 2
-	puts "Usage:    generate-lts-changelog.rb <LTS version> <weekly.yml>"
+if ARGV.length < 1 || ARGV.length > 2
+	puts "Usage:    generate-lts-changelog.rb <LTS version> [weekly.yml]"
+	puts ""
+	puts "Default weekly.yml: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml"
 	puts ""
 	puts "Missing argument <version> and/or <weekly.yml>"
 	puts "To generate the changelog for an LTS release:"
 	puts "          generate-lts-changelog.rb 2.164.3 /path/to/jenkins.io/content/_data/changelogs/weekly.yml"
+	puts ""
 	exit
 end
 
@@ -22,11 +27,23 @@ lts = ARGV[0]
 
 weekly_changelog_file = ARGV[1]
 
-backports_str = `set -o pipefail ; curl --fail -u #{curl_auth} -X POST --data '{"startAt":0, "maxResults":1000,"fields": ["key"], "jql": "labels = #{lts}-fixed" }' -H "Content-Type: application/json" https://issues.jenkins-ci.org/rest/api/2/search | jq -r '.issues[] | .key'`
+command = "set -o pipefail ; curl --fail -u #{curl_auth} -X POST --data '{\"startAt\":0, \"maxResults\":1000,\"fields\": [\"key\"], \"jql\": \"labels = #{lts}-fixed\" }' -H \"Content-Type: application/json\" https://issues.jenkins-ci.org/rest/api/2/search | jq -r '.issues[] | .key'"
+escaped_command = Shellwords.escape(command)
+backports_str = `bash -c #{escaped_command}`
 
 backports = backports_str.lines.collect { |x| x.chomp }
 
-changelog = YAML.load_file(weekly_changelog_file)
+if weekly_changelog_file == nil
+  puts "WARNING: Weekly changelog YAML is not specified. Using https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml"
+  weekly_changelog_file = "https://raw.githubusercontent.com/jenkins-infra/jenkins.io/master/content/_data/changelogs/weekly.yml"
+end
+
+if weekly_changelog_file =~ /https:\/\//
+	yaml_content = open(weekly_changelog_file){|f| f.read}
+	changelog = YAML::load(yaml_content)
+else
+	changelog = YAML.load_file(weekly_changelog_file)
+end
 
 backported_issues = []
 

--- a/lts-backports-changelog.rb
+++ b/lts-backports-changelog.rb
@@ -15,7 +15,7 @@ if ARGV.length < 1 || ARGV.length > 2
 	puts ""
 	puts "Default weekly.yml: https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml"
 	puts ""
-	puts "Missing argument <version> and/or <weekly.yml>"
+	puts "ERROR: Wrong argument number"
 	puts "To generate the changelog for an LTS release:"
 	puts "          generate-lts-changelog.rb 2.164.3 /path/to/jenkins.io/content/_data/changelogs/weekly.yml"
 	puts ""


### PR DESCRIPTION
Some fixes which actually make ` lts-backports-changelog` operational in Docker

- [x] Make the weekly.yml link in lts-backports-changelog optional 
- [x] Support HTTPS URLs as a source of weekly.yml in lts-backports-changelog
- [x] Fix failures of lts-backports-changelog on platforms where bash is not a default shell (like dash in Docker)

